### PR TITLE
fix(OTP 25): safe hmac/3 call

### DIFF
--- a/lib/ueberauth/strategy/facebook.ex
+++ b/lib/ueberauth/strategy/facebook.ex
@@ -180,8 +180,14 @@ defmodule Ueberauth.Strategy.Facebook do
     |> Base.encode16(case: :lower)
   end
 
+  @compile {:no_warn_undefined, {:crypto, :mac, 4}}
+  @compile {:no_warn_undefined, {:crypto, :hmac, 3}}
   defp hmac(data, type, key) do
-    :crypto.hmac(type, key, data)
+    if function_exported?(:crypto, :mac, 4) do
+      :crypto.mac(:hmac, type, key, data)
+    else
+      :crypto.hmac(type, key, data)
+    end
   end
 
   defp query_params(conn, :profile) do


### PR DESCRIPTION
Фикс для совместимости с OTP 24+ из основного репозитория.